### PR TITLE
Intermediate provider (#7628)

### DIFF
--- a/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-story-page/layout.php
+++ b/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-story-page/layout.php
@@ -98,8 +98,13 @@
                                                     <li><?=$provider?></li>
                                                 </ul>
                                             <?php endif; ?>
-                                    
-                                            <?php if ($value = $json ? dpla_get_field_value_by_arrayname($json, array('dataProvider')) : null): ?>
+
+                                            <?php 
+                                                $dataProvider = $json ? dpla_get_field_value_by_arrayname($json, array('dataProvider')) : null; 
+                                                $intermediateProvider = $json ? dpla_get_field_value_by_arrayname($json, array('intermediateProvider')) : null;
+                                                $value = implode("<br/> ", array_filter(array($dataProvider, $intermediateProvider)));
+                                                if ($value):
+                                             ?> 
                                                 <?php if ($provider != $value): ?>
                                                     <ul>
                                                         <li><h6>Data Provider</h6></li>

--- a/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-theme-page/layout.php
+++ b/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-theme-page/layout.php
@@ -97,8 +97,13 @@
                                                     <li><?=$provider?></li>
                                                 </ul>
                                             <?php endif; ?>
-                                    
-                                            <?php if ($value = $json ? dpla_get_field_value_by_arrayname($json, array('dataProvider')) : null): ?>
+
+                                            <?php 
+                                                $dataProvider = $json ? dpla_get_field_value_by_arrayname($json, array('dataProvider')) : null; 
+                                                $intermediateProvider = $json ? dpla_get_field_value_by_arrayname($json, array('intermediateProvider')) : null;
+                                                $value = implode("<br/> ", array_filter(array($dataProvider, $intermediateProvider)));
+                                                if ($value):
+                                             ?> 
                                                 <?php if ($provider != $value): ?>
                                                     <ul>
                                                         <li><h6>Data Provider</h6></li>


### PR DESCRIPTION
This branch adds the new MAPV3.1 field "intermediateProvider" to story and theme exhibit pages.  As in the frontend, intermediateProvider is listed under the heading "Data Provider" along with the "dataProvider" field. 

I was tempted move some of this logic to DPLAFunctions.php, as it feels like too much for view; however, I instead tried to maintain consistency with the amount and type of logic already in the view.  Refactoring may distract from other priorities at this time.

Redmine ticket: https://issues.dp.la/issues/7628
