### PR TITLE
Gif it up link (7721)

### DIFF
--- a/themes/dpla/common/header.php
+++ b/themes/dpla/common/header.php
@@ -113,6 +113,7 @@
                                 <li><a href="<?= $wpUrl ?>/get-involved/follow/">Follow Us</a></li>
                                 <li><a href="<?= $wpUrl ?>/forums">Forums</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/shop/">Shop</a></li>
+                                <li><a href="<?= $wpUrl ?>/gif-it-up/">GIF IT UP</a></li>
                             </ul>
                         </li>
                         <li class="aboutMenu">


### PR DESCRIPTION
Add "GIF IT UP" link to "Get involved" dropdown menu.  Link should resolve to "http://dp.la/info/gif-it-up/".  Fixes #7721.
