### PR TITLE
Revert "Modified UsersController to set cache-cancelling cookie for proxy"

### DIFF
--- a/README-DPLA-core-changes.md
+++ b/README-DPLA-core-changes.md
@@ -1,7 +1,6 @@
 
 The following changes have been made to the stock Omeka codebase:
 
-* [Modified UsersController to set cache-cancelling cookie for proxy](https://github.com/dpla/exhibitions/commit/b924e7dab383c954deea37df70f372654539d51b) (2014-02-28)
 * [HTML template changes](https://github.com/dpla/exhibitions/commit/f564af2957246a3cf847f23872989ad1938ceb29) (2013-04-09)
 * [Addition of debugging functions](https://github.com/dpla/exhibitions/commit/05aab1f5184a6e384c2557eb7d1dbc3c7dbee651) (2013-03-04)
 

--- a/application/controllers/UsersController.php
+++ b/application/controllers/UsersController.php
@@ -363,13 +363,7 @@ class UsersController extends Omeka_Controller_AbstractActionController
             // soon as the browser is terminated.
             Zend_Session::forgetMe();
         }
-
-        // We want to cache HTML pages with our proxy server that Omeka would normally
-        // not allow to be cached.  The problem is that private pages that are viewed by
-        // authenticated users can get stored in the cache.  As a workaround, set the following
-        // cookie so that our proxy can selectively ignore requests served to authenticated
-        // users.  Issue 7103.
-        setcookie('_dpla_no_cache', '1', 0, '/', '', false, true);  // params match Omeka session
+        
         $session = new Zend_Session_Namespace;
         if ($session->redirect) {
             $this->_helper->redirector->gotoUrl($session->redirect);
@@ -416,9 +410,6 @@ class UsersController extends Omeka_Controller_AbstractActionController
         $auth->clearIdentity();
         $_SESSION = array();
         Zend_Session::destroy();
-        // Crumble the cookie that's set in loginAction.
-        // '0' for cookie value is just symbolic.
-        setcookie('_dpla_no_cache', '0', 1, '/', '', false, true);  // params match Omeka session
         $this->_helper->redirector->gotoUrl('');
     }
     


### PR DESCRIPTION
This reverts commit b924e7dab383c954deea37df70f372654539d51b.

See dpla/automation#79 and https://issues.dp.la/issues/7799