### PR TITLE
remove extra paragraph tag

### DIFF
--- a/themes/dpla/exhibit-builder/exhibits/summary.php
+++ b/themes/dpla/exhibit-builder/exhibits/summary.php
@@ -54,7 +54,7 @@
             <?php if (($exhibitDescription = metadata('exhibit', 'description', array('no_escape' => true)))): ?>
                 <div class="exhibit-description">
                     <h5>Citation</h5>
-                    <p><?php echo $exhibitDescription; ?></p>
+                    <?php echo $exhibitDescription; ?>
                 </div>
             <?php endif; ?>
 		</div>


### PR DESCRIPTION
This removes an extra paragraph tag that was causing extra whitespace in the item citation.  The form automatically encloses the `exhibitDescription` text in a paragraph tag.