### PR TITLE
change css layout for theme menu

### DIFF
--- a/themes/dpla/css/main.css
+++ b/themes/dpla/css/main.css
@@ -627,7 +627,6 @@ line-height: 14px;
         }
             .thumbs-list li {
                 display: inline-block;
-                float: left;
                 margin: 0 20px 20px 0;
                 width: 128px;
                 vertical-align: top;
@@ -645,12 +644,6 @@ line-height: 14px;
                 color: #2b2b2b;
                 font-size: 100%;
                 margin: 1.5em 0 .5em 0;
-            }
-
-            /* Maintain even theme rows */
-            .overview-6 .thumbs-item-4,
-            .overview-8 .thumbs-item-5 {
-                clear: left;
             }
 
 
@@ -3616,15 +3609,6 @@ div.timeline-year {
 
 .fb_reset iframe {
     border: 0px none; width: 0px; height: 0px;
-}
-
-@media only screen and (max-width: 1000px) {
-    /* Maintain even theme rows */
-    .overview-4 .thumbs-item-3,
-    .overview-8 .thumbs-item-3,
-    .overview-8 .thumbs-item-7 {
-        clear: left;
-    }
 }
 
 @media only screen and (min-width: 681px) and (max-width: 980px) {


### PR DESCRIPTION
This changes the formatting of the theme menu on on exhibitions.  It addresses issue #7818 https://issues.dp.la/issues/7818

This removes CSS formatting that requires theme menus to have an even number of items in order to render properly.  It alters the css so that the menus will render responsively, creating rows of items based on the width of the browser window.  The variable heights of the items (caused by different theme title lengths) will not adversely affect the layout.