### PR TITLE
add break word property to left sidebar text

### DIFF
--- a/themes/dpla/css/main.css
+++ b/themes/dpla/css/main.css
@@ -634,7 +634,10 @@ line-height: 14px;
             .thumbs-list a {text-decoration: none;}
              .thumbs-list a img {border: 2px solid transparent;}
              .thumbs-list a:hover img { border-color: #808080; }
-            .exhibition-overview .leftSide {color: #818285;}
+            .exhibition-overview .leftSide {
+                color: #818285;
+                word-wrap: break-word;
+            }
             .exhibition-overview .leftSide section {
                 background-color: #ededed;
                 margin: 0 0 1em 0;


### PR DESCRIPTION
This addresses task #7824 https://issues.dp.la/issues/7824

It breaks very long words for word wrapping in the lefthand sidebar.  This is important for URLs in credits and citations, on browsers such as Chrome and Safari that do not automatically break words for word wrapping at the `/` character.

I have deployed this branch to staging to testing purposes.  You can go to http://staging.dp.la/exhibitions/exhibits/show/breadandroses.  Notice how the URL http://www.digitalcommonwealth.org in the lefthand sidebar wraps as you make the width of the browser window smaller.  