### PR TITLE
change dplafest link

### DIFF
--- a/themes/dpla/common/header.php
+++ b/themes/dpla/common/header.php
@@ -122,7 +122,7 @@
                                 <li><a href="<?= $wpUrl ?>/get-involved/groups/">Groups</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/workshops/">Workshops</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/events/">Events</a></li>
-                                <li><a href="<?= $wpUrl ?>/get-involved/dplafest/">DPLAfest</a></li>
+                                <li><a href="<?= $wpUrl ?>/get-involved/dplafest/april-2016/">DPLAfest</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/follow/">Follow Us</a></li>
                             </ul>
                         </li>


### PR DESCRIPTION
Change the DPLAfest link in the top menu to `http://dp.la/info/get-involved/dplafest/april-2016/`.  This addresses [ticket #8183](https://issues.dp.la/issues/8183).