### PR TITLE
Fix the application's awareness of SSL

### DIFF
--- a/admin/themes/default/common/login-header.php
+++ b/admin/themes/default/common/login-header.php
@@ -10,7 +10,7 @@
     <?php queue_css_file('layout'); ?>
     <?php queue_css_file('skeleton'); ?>
     <?php echo head_css(); ?>
-    <link href='http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
     <!-- JavaScripts -->
     <?php

--- a/application/libraries/Zend/Controller/Action/Helper/Redirector.php
+++ b/application/libraries/Zend/Controller/Action/Helper/Redirector.php
@@ -211,7 +211,7 @@ class Zend_Controller_Action_Helper_Redirector extends Zend_Controller_Action_He
     {
         if ($this->getUseAbsoluteUri() && !preg_match('#^(https?|ftp)://#', $url)) {
             $host  = (isset($_SERVER['HTTP_HOST'])?$_SERVER['HTTP_HOST']:'');
-            $proto = (isset($_SERVER['HTTPS'])&&$_SERVER['HTTPS']!=="off") ? 'https' : 'http';
+            $proto = request_is_ssl() ? 'https' : 'http';
             $port  = (isset($_SERVER['SERVER_PORT'])?$_SERVER['SERVER_PORT']:80);
             $uri   = $proto . '://' . $host;
             if ((('http' == $proto) && (80 != $port)) || (('https' == $proto) && (443 != $port))) {

--- a/application/libraries/Zend/View/Helper/ServerUrl.php
+++ b/application/libraries/Zend/View/Helper/ServerUrl.php
@@ -52,15 +52,7 @@ class Zend_View_Helper_ServerUrl
      */
     public function __construct()
     {
-        switch (true) {
-            case (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)):
-            case (isset($_SERVER['HTTP_SCHEME']) && ($_SERVER['HTTP_SCHEME'] == 'https')):
-            case (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == 443)):
-                $scheme = 'https';
-                break;
-            default:
-            $scheme = 'http';
-        }
+        $scheme = request_is_ssl() ? 'https' : 'http';
         $this->setScheme($scheme);
 
         if (isset($_SERVER['HTTP_HOST']) && !empty($_SERVER['HTTP_HOST'])) {

--- a/application/views/scripts/error/index.php
+++ b/application/views/scripts/error/index.php
@@ -11,7 +11,7 @@
     <link rel="stylesheet" media="all" href="<?php echo WEB_VIEW_SCRIPTS . '/css/style.css'; ?>">
     <link rel="stylesheet" media="all" href="<?php echo WEB_VIEW_SCRIPTS . '/css/skeleton.css'; ?>">
     <link rel="stylesheet" media="all" href="<?php echo WEB_VIEW_SCRIPTS . '/css/layout.css'; ?>">
-    <link href='http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 </head>
 <body id="debug">
     <div class="container container-sixteen">

--- a/application/views/scripts/functions.php
+++ b/application/views/scripts/functions.php
@@ -27,7 +27,7 @@ function admin_bar() {
  * Styles for admin bar.
  */
 function admin_bar_css() {
-    queue_css_url('http://fonts.googleapis.com/css?family=Arvo:400', 'screen');
+    queue_css_url('https://fonts.googleapis.com/css?family=Arvo:400', 'screen');
     queue_css_file('admin-bar', 'screen');
 }
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -41,7 +41,7 @@ define('SCRIPTS_DIR', APP_DIR . '/scripts');
 // Define the web address constants.
 
 // Set the scheme.
-$base_root = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+$base_root = request_is_ssl() ? 'https' : 'http';
 
 // Set the domain.
 if (!isset($_SERVER['HTTP_HOST'])) {
@@ -155,4 +155,18 @@ define('THEME_DIR', defined('ADMIN') ? ADMIN_THEME_DIR : PUBLIC_THEME_DIR);
 function stripslashes_deep($value)
 {
     return is_array($value) ? array_map('stripslashes_deep', $value) : stripslashes($value);
+}
+
+
+/**
+ * Determine whether the request is going over SSL, or is forwarded by a proxy
+ * that is doing SSL with the client.
+ */
+function request_is_ssl()
+{
+    $sh = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : false;
+    $reqIsHttps = ($sh && $sh != 'off');
+    $xForwardedProto = (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+                        && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https');
+    return ($reqIsHttps || $xForwardedProto);
 }

--- a/themes/default/common/header.php
+++ b/themes/default/common/header.php
@@ -23,7 +23,7 @@
     <!-- Stylesheets -->
     <?php
     queue_css_file('style');
-    queue_css_url('http://fonts.googleapis.com/css?family=PT+Serif:400,700,400italic,700italic');
+    queue_css_url('https://fonts.googleapis.com/css?family=PT+Serif:400,700,400italic,700italic');
     echo head_css();
 
     echo theme_header_background();

--- a/themes/seasons/common/header.php
+++ b/themes/seasons/common/header.php
@@ -15,7 +15,7 @@
 
     <!-- Stylesheets -->
     <?php
-    queue_css_url('http://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic');
+    queue_css_url('https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic');
     queue_css_file('style');
     echo head_css();
     ?>


### PR DESCRIPTION
Fix the Exhibitions application's understanding of whether a client request is for an `https://` resource. The "ssl" status determines URLs that are generated for links and asset resources.

In addition, fix some Google Font URLs to use https.

These are all to get rid of mixed-content errors in our browsers.
