### PR TITLE
use protocol-free url to google docs viewer

### DIFF
--- a/plugins/DocsViewer/DocsViewerPlugin.php
+++ b/plugins/DocsViewer/DocsViewerPlugin.php
@@ -13,7 +13,7 @@
  */
 class DocsViewerPlugin extends Omeka_Plugin_AbstractPlugin
 {
-    const API_URL = 'http://docs.google.com/viewer';
+    const API_URL = '//docs.google.com/viewer';
     
     const DEFAULT_VIEWER_EMBED = 1;
     


### PR DESCRIPTION
This fixes the google docs viewer to work with HTTPS.

Unfortunately the only way to address this issue is to make a change to the Omeka DocsViewer plugin.  An identical fix has been merged into the code base, but has not yet been released: https://github.com/omeka/plugin-DocsViewer/commit/d28ee1ff39f5c25f412d62c43fe0c1b52f058b0c  The last stable release of the plugin was in 2013, so I don't think we can anticipate another one anytime soon.

This has been tested on staging.  It addresses [ticket #8483](https://issues.dp.la/issues/8483).