### PR TITLE
change dplafest main menu link

### DIFF
--- a/themes/dpla/common/header.php
+++ b/themes/dpla/common/header.php
@@ -123,7 +123,7 @@
                                 <li><a href="<?= $wpUrl ?>/get-involved/groups/">Groups</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/workshops/">Workshops</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/events/">Events</a></li>
-                                <li><a href="<?= $wpUrl ?>/get-involved/dplafest/april-2016/">DPLAfest</a></li>
+                                <li><a href="<?= $wpUrl ?>/get-involved/dplafest/">DPLAfest</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/follow/">Follow Us</a></li>
                             </ul>
                         </li>


### PR DESCRIPTION
Change the DPLAfest link in the main menu.  This addresses [ticket #8552](https://issues.dp.la/issues/8552).