### PR TITLE
Feature/page layout

### DIFF
--- a/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-story-page/layout.php
+++ b/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-story-page/layout.php
@@ -16,12 +16,18 @@
                                 echo files_for_item(array(), array('class'=>'item-file'), $item['item']);
                             }
                             ?>
-                            <span data-id="<?=$unique_id?>" class="show-item-details cboxElement"><span>i</span></span>
                         </div>
 
                         <div class="caption">
                             <?=$item['caption']?>
+                            <span data-id="<?=$unique_id?>" class="show-item-details cboxElement"><a>More info</a></span>
                         </div>
+
+                        <?php if (count($items) > 1): ?>
+                            <div class="caption">
+                                <strong>Select an item:</strong>
+                            </div>
+                        <?php endif; ?>
 
                         <div class="overlay">
                             <div id="<?=$unique_id?>">

--- a/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-theme-page/layout.php
+++ b/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-theme-page/layout.php
@@ -17,12 +17,18 @@
                                 echo files_for_item(array(), array('class'=>'item-file'), $item['item']);
                             }
                             ?>
-                            <span data-id="<?=$unique_id?>" class="show-item-details cboxElement"><span>i</span></span>
                         </div>
                    
                         <div class="caption">
                             <?=$item['caption']?>
+                            <span data-id="<?=$unique_id?>" class="show-item-details cboxElement"><a>More info</a></span>
                         </div>
+
+                        <?php if (count($items) > 1): ?>
+                            <div class="caption">
+                                <strong>Select an item:</strong>
+                            </div>
+                        <?php endif; ?>
 
                         <div class="overlay">
                             <div id="<?=$unique_id?>">

--- a/themes/dpla/css/main.css
+++ b/themes/dpla/css/main.css
@@ -623,7 +623,7 @@ line-height: 14px;
             list-style: none;
             margin: 0;
             overflow: hidden;
-            padding: 0 0 0 20px;
+            padding: 20px 0 0 20px;
         }
             .thumbs-list li {
                 display: inline-block;
@@ -2498,8 +2498,7 @@ aside h5 { margin: 5px 0 1em; }
 .slide-container {
     position: relative;
 }
-.moreInfo,
-.show-item-details {
+.moreInfo {
     background: #000;
     border: 1px solid #95928F;
     bottom: 17px;
@@ -2518,33 +2517,23 @@ aside h5 { margin: 5px 0 1em; }
     -ms-transition: 0.3s ease;
     transition: 0.3s ease;
 }
-.show-item-details {
-    font-size: 1.4em;
-    top: 15px;
-    left: 15px;
-}
-.video-mp4 + .show-item-details {
-    position: static;
-    border: none;
-    float: right;
-    margin: 1.5%;
-}
 .moreInfo.hover {
     border-color: #fff;
     background-color: transparent;
     text-decoration: none;
 }
-.show-item-details:hover {
-    text-decoration: none;
-    background: #000;
-}
-.moreInfo span,
-.show-item-details span {
+.moreInfo span {
     color: #fff;
     text-transform: none;
     text-align: center;
     padding: .15em .05em 0 0;
     display: block;
+}
+span.show-item-details {
+    cursor: pointer;
+    /* this overrides the background color for .show-item-details defined
+       in dpla-colors.css, which is in the frontend-assets app */
+    background-color: transparent;
 }
 .flex-direction-nav a {
     transition: .5s ease;
@@ -3038,7 +3027,7 @@ footer .social li span { height: 31px; border-right: 1px solid #000000; border-b
     position: relative;
     clear: both;
     width: 65.820106%;
-    float: right;
+    float: left;
 }
 .slidegallery {
     background: none repeat scroll 0 0 #EDEDED;
@@ -3051,12 +3040,15 @@ footer .social li span { height: 31px; border-right: 1px solid #000000; border-b
     width: 100%;
 }
 .slide_bottom {
-    float: left;
+    float: right;
     width: 32%;
 }
 
 .caption {
     padding: 1% 2%;
+}
+.caption p {
+    display: inline;
 }
 .slide-Container .slides .caption {
     clear: none;
@@ -3535,7 +3527,6 @@ div.timeline-year {
 .no-js .next, 
 .no-js .prev, 
 .no-js .moreInfo, 
-.no-js .show-item-details,
 .no-js .cboxClose.pclose,
 .no-js .prevNext,
 .no-js .desc-toggle,
@@ -4210,8 +4201,7 @@ aside { height: 100%; }
 #toggle { display: inline-block; }
 
 /* HOME SLIDESHOW*/
-.moreInfo,
-.show-item-details {
+.moreInfo {
     background-position: center center;
     padding: 6px;
     right: 17px;

--- a/themes/dpla/exhibit-builder/exhibits/show.php
+++ b/themes/dpla/exhibit-builder/exhibits/show.php
@@ -40,7 +40,7 @@ echo head(array(
             <h2><?php echo metadata('exhibit_page', 'title'); ?></h2>
         </div>
         <div class="sideNav">
-            <span class="head">Themes <span class="icon-arrow-down" aria-hidden="true"></span></span>
+            <span class="head">Sections <span class="icon-arrow-down" aria-hidden="true"></span></span>
             <?php echo dpla_theme_nav(); ?>
         </div>  
     </div>

--- a/themes/dpla/exhibit-builder/exhibits/summary.php
+++ b/themes/dpla/exhibit-builder/exhibits/summary.php
@@ -92,7 +92,6 @@
 
             <?php if ($pagesCount > 0): ?>
                 <div class="module overview overview-<?php echo $pagesCount; ?>">
-                    <h2>Choose a theme</h2>
                     <?php echo $thumbsList; ?>
                 </div>
             <?php endif; ?>


### PR DESCRIPTION
This makes some small changes to the layout and style of exhibitions pages in order to improve user experience.  These UX solutions were designed by Franky and Samantha.

Changes include:
1) Eliminate the word "themes" or change it to "sections" for clarity
2) Swap the position of the image viewer and its accompanying text
3) Add the text "Select an item" above menus of clickable thumbnails
4) Replace the "i" icon on the image viewer with a "More info" link at the end of the image caption

Here's a "before" screenshot:

<img width="888" alt="screen shot 2016-10-13 at 7 39 32 pm" src="https://cloud.githubusercontent.com/assets/3615206/19370927/13a4b5d2-917d-11e6-805e-49f6b90f0442.png">


...and an "after" screenshot:

<img width="889" alt="screen shot 2016-10-13 at 7 40 50 pm" src="https://cloud.githubusercontent.com/assets/3615206/19370932/17fdfd6e-917d-11e6-964c-854fca7d7660.png">


Franky and Samantha have approved these changes on staging.