### PR TITLE
Load each Javascript file only once per page

### DIFF
--- a/themes/dpla/common/footer.php
+++ b/themes/dpla/common/footer.php
@@ -51,17 +51,21 @@
     </footer><!-- end footer -->
     </div>
         <!-- JavaScripts -->
-    <?php queue_js_file('vendor/jquery.mobile-1.2.0.min'); ?>
-    <?php queue_js_file('vendor/fastclick'); ?>
-    <?php queue_js_file('jquery.jcarousel.min'); ?>
-    <?php queue_js_file('vendor/jquery.opacityrollover'); ?>
-    <?php queue_js_file('vendor/jquery.colorbox-min'); ?>
-    <?php queue_js_file('vendor/selectivizr', 'javascripts', array('conditional' => '(gte IE 6)&(lte IE 8)')); ?>
-    <?php queue_js_file('vendor/respond'); ?>
-    <?php queue_js_file('plugins'); ?>
-    <?php queue_js_file('main'); ?>
-    <?php queue_js_file('globals'); ?>
-    <?php echo head_js(); ?>
+    <?php
+        # Load individual javascipt files. The JavaScript file queue is not 
+        # used here to avoid duplication of files from the header.
+        # @see themes/dpla/common/header.php
+    ?>
+    <?php echo js_tag('vendor/jquery.mobile-1.2.0.min'); ?>
+    <?php echo js_tag('vendor/fastclick'); ?>
+    <?php echo js_tag('jquery.jcarousel.min'); ?>
+    <?php echo js_tag('vendor/jquery.opacityrollover'); ?>
+    <?php echo js_tag('vendor/jquery.colorbox-min'); ?>
+    <?php echo js_tag('vendor/selectivizr', 'javascripts', array('conditional' => '(gte IE 6)&(lte IE 8)')); ?>
+    <?php echo js_tag('vendor/respond'); ?>
+    <?php echo js_tag('plugins'); ?>
+    <?php echo js_tag('main'); ?>
+    <?php echo js_tag('globals'); ?>
 
     <ul class="jump-links">
         <li><a href="#top-nav" accesskey="1">Return to top navigation</a></li>

--- a/themes/dpla/common/header.php
+++ b/themes/dpla/common/header.php
@@ -45,6 +45,12 @@
     echo head_css();
     ?>
     <?php queue_js_file('vendor/modernizr-2.6.2.min'); ?>
+    <?php 
+        # Load all JavaScripts in file queue, including those included in _head
+        # function in plugins.
+        # Note that some JavaScript files are loaded in the footer.
+        # @see themes/dpla/common/footer.php
+    ?>
     <?php echo head_js(); ?>
 </head>
 <?php echo body_tag(array('id' => @$bodyid, 'class' => @$bodyclass)); ?>


### PR DESCRIPTION
This fixes duplication of JavaScript in the header and footer of rendered HTML.  The most severe outcome of this duplication was the double-counting of pageviews in Google Analytics since the August upgrade of the GoogleAnalytics plugin.

The JavaScript file queue is used in the header, following Omeka convention.  Before it was being used in both the header and footer.  Since some plugins use the queue to load JavaScripts, we should keep queued JavaScripts in the header to avoid unintended breakages.  Javascripts that need to go (or that have in the past gone) in the footer are loaded individually using the `js_tag` helper function.

I have tested this on staging to make sure that
1. Only one beacon is being sent to Google Analytics to record a pageview
2. Each JavaScript file is being loaded once and only once
3. Javascript-dependent functionality seems to be working

This branch is currently on staging, so feel free to do some of your own testing if you'd like. Samantha is also doing some informal testing on the staging site - I will post in this PR once she is done.

This addresses tickets [#8601](https://issues.dp.la/issues/8601) and [#7140](https://issues.dp.la/issues/7140).