### PR TITLE
Add Google Analytics event tracking for item views

### DIFF
--- a/plugins/ExhibitBuilder/helpers/DPLAFunctions.php
+++ b/plugins/ExhibitBuilder/helpers/DPLAFunctions.php
@@ -592,12 +592,24 @@ class MetadataTable {
  */
 class ItemMetadata {
     
-    private $item = null;
-    private $json = null;
+    private $item;
+    private $json;
 
     function __construct($item) {
         $this->item = $item;
-        $this->json = get_dpla_api_object(dpla_get_field_value_by_name($item, 'Has Version'));
+    }
+
+    /* 
+     * Lazy load $json.
+     * If the inital call to the API does not return a valid record, the value
+     * of $json will be set to an empty string (@see get_dpla_api_object), and
+     * will subsequently evaluate FALSE for !isset().
+     */
+    private function get_json() {
+        if(!isset($this->json)) {
+            $this->json = get_dpla_api_object(dpla_get_field_value_by_name($this->item, 'Has Version'));
+        }
+        return $this->json;
     }
 
     function get_title($opts = array('api_preferred' => false)) {
@@ -632,8 +644,8 @@ class ItemMetadata {
     }
 
     function get_edm_rights() {
-        $edm_rights = $this->json ? 
-            dpla_get_field_value_by_arrayname($this->json, array('rights')) : null; 
+        $edm_rights = $this->get_json() ? 
+            dpla_get_field_value_by_arrayname($this->get_json(), array('rights')) : null; 
         return $edm_rights;  
     }
 
@@ -645,15 +657,15 @@ class ItemMetadata {
     }
 
     function get_data_provider() {
-        $data_provider = $this->json ? 
-            dpla_get_field_value_by_arrayname($this->json, array('dataProvider')) : null;
+        $data_provider = $this->get_json() ? 
+            dpla_get_field_value_by_arrayname($this->get_json(), array('dataProvider')) : null;
         return $data_provider;
     }
 
     function get_contributing_institution() {
         $data_provider = $this->get_data_provider();
-        $intermediate_provider = $this->json ? 
-            dpla_get_field_value_by_arrayname($this->json, array('intermediateProvider')) : null;
+        $intermediate_provider = $this->get_json() ? 
+            dpla_get_field_value_by_arrayname($this->get_json(), array('intermediateProvider')) : null;
         $contributing_institution = array_filter(array($data_provider, $intermediate_provider));
         return $contributing_institution;
     }
@@ -663,8 +675,8 @@ class ItemMetadata {
     }
 
     function get_id() {
-        $id = $this->json ? 
-            dpla_get_field_value_by_arrayname($this->json, array('id')) : null; 
+        $id = $this->get_json() ? 
+            dpla_get_field_value_by_arrayname($this->get_json(), array('id')) : null; 
         return $id;
     }
 
@@ -677,15 +689,24 @@ class ItemMetadata {
      */
     private function get_field_value($omeka_field_name, $api_field_name, $api_preferred = false) {
 
-        $omeka_field_value = dpla_get_field_value_by_name($this->item, $omeka_field_name);
-        $api_field_value = $this->json ? 
-            dpla_get_field_value_by_arrayname($this->json, $api_field_name) : null;
         $field_value = null;
 
         if ($api_preferred == false) {
-            $field_value = $omeka_field_value ?: $api_field_value;
+            // get value from omeka
+            $field_value = dpla_get_field_value_by_name($this->item, $omeka_field_name);
+
+            // if omeka value unavailable, get value from api
+            if($field_value == null && $this->get_json() != false) {
+                $field_value = dpla_get_field_value_by_arrayname($this->get_json(), $api_field_name);
+            }
         } else {
-            $field_value = $api_field_value ?: $omeka_field_value;
+            // get value from api
+            if($this->get_json() != false) {
+                $field_value = dpla_get_field_value_by_arrayname($this->get_json(), $api_field_name);
+            // if api value is unavailable, get value from omeka
+            } else {
+                $field_value = dpla_get_field_value_by_name($this->item, $omeka_field_name);
+            }
         }
         
         return $field_value;

--- a/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-story-page/layout.php
+++ b/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-story-page/layout.php
@@ -6,7 +6,18 @@
             <ul class="slides <?= count($items) == 1 ? "single-slide" : ""?>">
 
                 <?php foreach ($items as $item): ?>
-                    <li data-thumb="<?=$item['file_uri_square'] ?>" class="flexslider-slide">
+                    <?php
+                        //@see class ItemMetadata, DPLAFunctions.php
+                        $item_metadata = new ItemMetadata($item);
+                        $metadata_opts = array('api_preferred' => true)
+                    ?>
+                    <li data-thumb="<?=$item['file_uri_square'] ?>"
+                        data-item-id="<?=$item_metadata->get_id() ?>"
+                        data-provider="<?=$item_metadata->get_provider($metadata_opts) ?>"
+                        data-data-provider="<?=$item_metadata->get_data_provider() ?>"
+                        data-title="<?=$item_metadata->get_title($metadata_opts) ?>"
+                        class="flexslider-slide">
+
                         <div class="plugin-content">
                             <?php
                             $unique_id = "itemDetailsBox_".hash("md4", exhibit_builder_exhibit_item_uri($item['item']));

--- a/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-theme-page/layout.php
+++ b/plugins/ExhibitBuilder/views/shared/exhibit_layouts/dpla-theme-page/layout.php
@@ -6,8 +6,18 @@
             <ul class="slides <?= count($items) == 1 ? "single-slide" : ""?>">
 
                 <?php foreach ($items as $item): ?>
-    
-                    <li data-thumb="<?=$item['file_uri_square'] ?>" class="flexslider-slide">
+                    <?php
+                        //@see class ItemMetadata, DPLAFunctions.php
+                        $item_metadata = new ItemMetadata($item);
+                        $metadata_opts = array('api_preferred' => true)
+                    ?>
+                    <li data-thumb="<?=$item['file_uri_square'] ?>"
+                        data-item-id="<?=$item_metadata->get_id() ?>"
+                        data-provider="<?=$item_metadata->get_provider($metadata_opts) ?>"
+                        data-data-provider="<?=$item_metadata->get_data_provider() ?>"
+                        data-title="<?=$item_metadata->get_title($metadata_opts) ?>"
+                        class="flexslider-slide">
+
                         <div class="plugin-content">
                             <?php
                             $unique_id = "itemDetailsBox_".hash("md4", exhibit_builder_exhibit_item_uri($item['item']));

--- a/themes/dpla/common/header.php
+++ b/themes/dpla/common/header.php
@@ -44,14 +44,17 @@
     queue_css_file('galleriffic');
     echo head_css();
     ?>
-    <?php queue_js_file('vendor/modernizr-2.6.2.min'); ?>
     <?php 
+        # Add files to the JavaScript file queue.
+        queue_js_file('vendor/modernizr-2.6.2.min');
+        queue_js_file('google-analytics-events');
+
         # Load all JavaScripts in file queue, including those included in _head
         # function in plugins.
         # Note that some JavaScript files are loaded in the footer.
         # @see themes/dpla/common/footer.php
+        echo head_js();
     ?>
-    <?php echo head_js(); ?>
 </head>
 <?php echo body_tag(array('id' => @$bodyid, 'class' => @$bodyclass)); ?>
     <?php # fire_plugin_hook('public_body', array('view'=>$this)); ?>

--- a/themes/dpla/exhibit-builder/exhibits/summary.php
+++ b/themes/dpla/exhibit-builder/exhibits/summary.php
@@ -38,8 +38,15 @@
                             $thumbItemUri = $att['item_uri'];
                         }
                     }
+                    $item_metadata = new ItemMetadata($att);
                 ?>
-                <img src="<?=$thumbUri?>" alt="slide">
+                <img src="<?=$thumbUri?>"
+                     alt="slide"
+                     data-item-id="<?=$item_metadata->get_id() ?>"
+                     data-provider="<?=$item_metadata->get_provider($metadata_opts) ?>"
+                     data-data-provider="<?=$item_metadata->get_data_provider() ?>"
+                     data-title="<?=$item_metadata->get_title($metadata_opts) ?>">
+
                 <div class="caption">
                     <?=$thumbCaption ?>
                 </div>

--- a/themes/dpla/javascripts/google-analytics-events.js
+++ b/themes/dpla/javascripts/google-analytics-events.js
@@ -1,0 +1,54 @@
+/*
+ * Tracks custom events with Google Analytics.
+ * This application uses the GoogleAnalytics plugin to track general usage
+ * data. This file defines additional user interations to be tracked with Google
+ * Analtyics.
+ * See https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+ */
+
+jQuery(function($) {
+
+  $(document).ready(function(){
+    trackViewExhibitionItemEvent(trackableItems());
+  });
+
+  /*
+   * Get all DOM elements representing trackable items.
+   *
+   * This assumes that all relevant object have a 'data-item-id' attribute,
+   * whether or not the value of that attribute is a valid id.
+   * Objects with 'data-item-id=""' or 'data-item-id=null' will be returned.
+   *
+   * @return [jQuery Object] an enumerable containing zero to many DOM objects.
+   */
+  var trackableItems = function(){
+    return $("[data-item-id]");
+  };
+
+  /* 
+   * Track view of an item within an exhibition.
+   * Relies on data-* attributes embedded in the HTML of the page.
+   *
+   * @param [jQuery Object] an enumerable containing zero to many DOM objects.
+   */
+  var trackViewExhibitionItemEvent = function(items){
+    /* 
+     * 'ga' must be defined for a signal to be sent to Google Analtyics.
+     * It is set by the GoogleAnaltyics plugin.
+     */
+    if (typeof ga !== 'undefined') {
+
+      items.each(function(){
+        // 'this' represents a single DOM object with a data-item-id attribute
+        var provider = $(this).attr("data-provider") || "undefined";
+        var item_id = $(this).attr("data-item-id") || "undefined";
+        var title = $(this).attr("data-title") || "undefined";
+        var category = "View Exhibition Item : " + provider;
+        var action = $(this).attr("data-data-provider") || "undefined";
+        var label = item_id + " : " + title;
+
+        ga('send', 'event', category, action, label);
+      });
+    }
+  };
+});


### PR DESCRIPTION
This adds Google Analytics event tracking for views of full-sized items in exhibitions.

There are two sources of metadata for any item: the Omeka database and the DPLA API.  The Omeka database stores information that the curators enter through the dashboard.  The purpose of curator-provided metadata is threefold:
1. Curators can use fields that aren't available through the DPLA API, such as formatted citations.
2. Curators can override fields that may have opaque or poorly formatted data in the API, such as titles.
3. Curators can provide data for items that are not in the DPLA API.  Sometimes they get special permission to use an item we don't have through the API, and sometimes items that were initially available through the API are no longer there.

The existing `ItemMetadata` class provides functions for getting item metadata from either the Omeka database or the API.  It's existing functionality privileges data from Omeka (which supports #2 above) and falls back to data from the API if Omeka data is unavailable.  For the purposes of collecting and aggregating usage stats, we want the opposite - API data if it as available, then fall back to Omeka data. This PR adds an optional parameter to relevant functions to indicate a preference for API data.

Item metadata is made available to JavaScript functions through HTML `data-*` attributes.  This follows the convention used in other frontend applications.  The beacons sent to Google Analytics via JavaScript also follow a format used in other apps:

```
Category: "View Exhibition Item : [provider name]"
Action: "[data provider name]"
Label: "[item id] : [item title]"
```

Some pages have slideshows with multiple items, in which case all items in the slideshow are tracked as views when the page loads.  According to FA, it would be nice to track items one by one as they are viewed, but not required.  Due to time restraints I am not pursuing that feature in this PR.

This has been testing on staging using the Google Analytics Debugger plugin.  It addresses [ticket #8441](https://issues.dp.la/issues/8441).
