### PR TITLE
add meta referrer tag

### DIFF
--- a/themes/dpla/common/header.php
+++ b/themes/dpla/common/header.php
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta content="width=device-width" name="viewport">
+    <meta name="referrer" content="origin-when-cross-origin" />
     <?php if ( $description = option('description')): ?>
     <meta name="description" content="<?php echo $description; ?>" />
     <?php endif; ?>


### PR DESCRIPTION
This adds a meta referrer tag to the head of each page.  This will allow external sites not using HTTPS to track traffic from DPLA.  It has been tested on staging.  This addresses ticket [DT-1201](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1201).