### PR TITLE
remove events from menu

### DIFF
--- a/themes/dpla/common/header.php
+++ b/themes/dpla/common/header.php
@@ -132,7 +132,6 @@
                                 <li><a href="<?= $wpUrl ?>/gif-it-up/">GIF IT UP</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/groups/">Groups</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/workshops/">Workshops</a></li>
-                                <li><a href="<?= $wpUrl ?>/get-involved/events/">Events</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/dplafest/">DPLAfest</a></li>
                                 <li><a href="<?= $wpUrl ?>/get-involved/follow/">Follow Us</a></li>
                             </ul>


### PR DESCRIPTION
This removes the "Events" link from the "Get Involved" menu.  It has been tested on staging.  It addresses [DT-1195](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1195).