### PR TITLE
change conditional

### DIFF
--- a/plugins/ExhibitBuilder/helpers/DPLAFunctions.php
+++ b/plugins/ExhibitBuilder/helpers/DPLAFunctions.php
@@ -671,7 +671,7 @@ class ItemMetadata {
         // get field value from omeka
         $field_value = dpla_get_field_value_by_name($this->item, $omeka_field_name);
 
-        if ($api_preferred == true) {
+        if ($api_preferred == true || $field_value == null) {
             // get field value from api
             $api_field_value = $this->lookup_api_field($api_field_name);
 


### PR DESCRIPTION
This fixes a conditional statement related to populating item metadata from the DPLA API.  Item metadata can come from two sources: the DPLA API and admin-entered metadata.  Before this PR, the app was pulling from the DPLA API only for certain fields.  Now, it also pulls from the DPLA API for ANY field IF there is no admin-entered data.

This has been tested on staging.  It addresses [ticket DT-1176](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1176).